### PR TITLE
[shipit-0224] add strict null checks to tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,16 @@
 {
-    "compilerOptions": {
-      "target": "es2020",
-      "module": "commonjs",
-      "lib": ["dom", "es6"],
-      "outDir": "dist",
-      "rootDir": "src",
-      "removeComments": true,
-      "esModuleInterop": true,
-      "inlineSourceMap": true,
-      "noEmitOnError": true
-    },
-    "exclude": ["node_modules"],
-    "include": ["src/**/*.ts", "src/config"]
-  }
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "lib": ["dom", "es6"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "removeComments": true,
+    "esModuleInterop": true,
+    "inlineSourceMap": true,
+    "noEmitOnError": true,
+    "strictNullChecks": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["src/**/*.ts", "src/config"]
+}


### PR DESCRIPTION
# Goal

avoid allowing `null` and `undefined` as valid values for types (unless otherwise explicitly stated).