### PR TITLE
(fix) Start Apollo Server before applying middleware

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,9 @@ app.use(xrayExpress.openSegment(serviceName));
 AWSXRay.middleware.enableDynamicNaming('*');
 
 //Apply the GraphQL middleware into the express app
-server.applyMiddleware({ app, path: '/' });
+server.start().then(() => {
+  server.applyMiddleware({ app, path: '/' });
+});
 
 //Make sure the express app has the xray close segment handler
 app.use(xrayExpress.closeSegment());


### PR DESCRIPTION
## Goal

This is a required step for Apollo Server v.3. Since package.json now has v.3 by default, we need to tweak the applying middleware step accordingly. 

From [the docs](https://www.apollographql.com/docs/apollo-server/migration/#start-now-mandatory-for-non-serverless-framework-integrations):

> In Apollo Server 3, you must await server.start() immediately after new ApolloServer before calling applyMiddleware (or getMiddleware or getHandler, depending on the integration). Note that you don't have to call it before calling the testing method executeOperation. Otherwise, that method will throw.