### PR TITLE
(fix) Update ESLint config - Prettier plugins have been rolled into one

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,51 +1,50 @@
 module.exports = {
-    extends: [
-        'eslint:recommended',
-        'plugin:@typescript-eslint/eslint-recommended',
-        'plugin:@typescript-eslint/recommended',
-        'prettier/@typescript-eslint',
-        'plugin:prettier/recommended',
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  plugins: [],
+  rules: {
+    'prettier/prettier': [
+      'error',
+      {
+        useTabs: false, // ＼(￣▽￣)／
+        tabWidth: 2,
+        semi: true,
+        singleQuote: true,
+      },
     ],
-    plugins: [],
-    rules: {
-        'prettier/prettier': [
-            'error',
-            {
-                useTabs: false, // ＼(￣▽￣)／
-                tabWidth: 2,
-                semi: true,
-                singleQuote: true,
-            },
-        ],
-        // allows unused vars when declared in arguments
-        '@typescript-eslint/no-unused-vars': [
-            'error',
-            { vars: 'all', args: 'none' },
-        ],
-        // disables case checks for class/interface/type
-        '@typescript-eslint/class-name-casing': 0,
-        // disables case checks for properties
-        '@typescript-eslint/camelcase': 0,
-        // allows 'any' typehint
-        '@typescript-eslint/no-explicit-any': 0,
-        // enforces 2 spaces indent
-        indent: [
-            'error',
-            2,
-            {
-                SwitchCase: 1,
-                VariableDeclarator: { var: 2, let: 2, const: 3 },
-                outerIIFEBody: 1,
-                MemberExpression: 1,
-                FunctionDeclaration: { parameters: 1, body: 1 },
-                FunctionExpression: { parameters: 1, body: 1 },
-                CallExpression: { arguments: 1 },
-                ArrayExpression: 1,
-                ObjectExpression: 1,
-                ImportDeclaration: 1,
-                flatTernaryExpressions: false,
-                ignoreComments: false,
-            },
-        ],
-    },
+    // allows unused vars when declared in arguments
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { vars: 'all', args: 'none' },
+    ],
+    // disables case checks for class/interface/type
+    '@typescript-eslint/class-name-casing': 0,
+    // disables case checks for properties
+    '@typescript-eslint/camelcase': 0,
+    // allows 'any' typehint
+    '@typescript-eslint/no-explicit-any': 0,
+    // enforces 2 spaces indent
+    indent: [
+      'error',
+      2,
+      {
+        SwitchCase: 1,
+        VariableDeclarator: { var: 2, let: 2, const: 3 },
+        outerIIFEBody: 1,
+        MemberExpression: 1,
+        FunctionDeclaration: { parameters: 1, body: 1 },
+        FunctionExpression: { parameters: 1, body: 1 },
+        CallExpression: { arguments: 1 },
+        ArrayExpression: 1,
+        ObjectExpression: 1,
+        ImportDeclaration: 1,
+        flatTernaryExpressions: false,
+        ignoreComments: false,
+      },
+    ],
+  },
 };


### PR DESCRIPTION
After fixing this issue for `prospect-curation-api` here: https://github.com/Pocket/prospect-curation-api/pull/18, I'm submitting an identical PR to fix the template.

## Goal

This removes an annoying IDE error - unable to parse ESLint config.

See info at https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21

It appears that the config file also had 4 space indents rather than 2 space ones, so instead of one line the entire file is being replaced.

