### PR TITLE
Update npm in codebuild and do npm ci

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -54,7 +54,8 @@ phases:
       - tfenv install
       - tfenv use $(cat .terraform-version)
 
-      - npm install
+      - npm install -g npm@latest
+      - npm ci
       - npm run get
       - npm run build
       # synthesize the js into terraform json with the proper node environment


### PR DESCRIPTION
## Goal
Prevent errors in CodeBuild because it uses an outdated npm version.

- Update npm to the latest version
- Run `npm ci` to install directly from `package-lock.yml`, without changing `package-lock.yml`.

## Implementation Decisions
- This change fixed a build error in one of our internal repos. We're not entirely sure why that repo was affected and other's weren't.
```
[Container] 2021/09/02 22:21:26 Running command npm install
npm ERR! code EBADPLATFORM
npm ERR! notsup Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm ERR! notsup Valid OS:    darwin
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   linux
npm ERR! notsup Actual Arch: x64
```

## References

Slack thread:
* https://pocket.slack.com/archives/C03QVL4SU/p1630623238120600
