### PR TITLE
fix(linter): fixing errors with the github super linter

### DIFF
--- a/.github/linters/.eslintrc.js
+++ b/.github/linters/.eslintrc.js
@@ -1,1 +1,0 @@
-../../.eslintrc.js

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,6 +15,8 @@ name: Lint Code Base
 # Start the job on all pull requests #
 #############################
 on:
+  # Run on every pull request created or updated
+  # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request
   pull_request:
 
 ###############
@@ -45,23 +47,48 @@ jobs:
         uses: actions/setup-node@v2.5.1
         with:
           node-version: 16.x
+      # Install our eslint packages.
+      # We may have custom tsconfigs, eslints that are brought in via a package.
       - run: npm install
 
       ################################
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
+
+        # We use the Github super linter, it can be cranky at times, so in that moment here are the docs https://github.com/github/super-linter
         uses: docker://ghcr.io/github/super-linter:slim-v4
+
+        # All Environment variables are defined here https://github.com/github/super-linter#environment-variables
         env:
-          # All Environment variables are defined here https://github.com/github/super-linter#environment-variables
           # The name of the repository default branch.
           DEFAULT_BRANCH: main
-          # Directory for all linter configuration rules. We symlink our root .eslintrc.js to this directory
+
+          # Directory for all linter configuration rules.
+          # This is the root of our codebase.
           LINTER_RULES_PATH: /
+
+          # Will parse the entire repository and find all files to validate across all types.
+          # NOTE: When set to false, only new or edited files will be parsed for validation.
           VALIDATE_ALL_CODEBASE: true
+
+          # Filename for ESLint configuration (ex: .eslintrc.yml, .eslintrc.json)
           TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.js
-          VALIDATE_TERRAFORM: true
+
+          #####
+          # Note: All the VALIDATE[LANGUAGE] variables behave in a specific way.
+          # If none of them are passed, then they all default to true.
+          # However if any one of the variables are set, we default to leaving any unset variable to false.
+          # This means that if you run the linter “out of the box”, all languages will be checked.
+          # But if you wish to select specific linters, we give you full control to choose which linters are run, and won’t run anything unexpected.
+          ####
+
+          # Flag to enable or disable the linting process of the JavaScript language. (Utilizing: eslint)
+          # Will validate any raw *.js in the repo like a jest.config.js
           VALIDATE_JAVASCRIPT_ES: true
-          VALIDATE_MD: true
+
+          # Flag to enable or disable the linting process of the TypeScript language. (Utilizing: eslint)
           VALIDATE_TYPESCRIPT_ES: true
+
+          # Flag to enable or disable the linting process of the YAML language.
           VALIDATE_YAML: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -57,4 +57,8 @@ jobs:
           LINTER_RULES_PATH: /
           VALIDATE_ALL_CODEBASE: true
           TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.js
-          VALIDATE_TYPESCRIPT_STANDARD: false
+          VALIDATE_TERRAFORM: true
+          VALIDATE_JAVASCRIPT_ES: true
+          VALIDATE_MD: true
+          VALIDATE_TYPESCRIPT_ES: true
+          VALIDATE_YAML: true

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           node-version: 16.x
       - run: npm install
-      - run: echo "hi
 
       ################################
       # Run Linter against code base #

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -53,7 +53,10 @@ jobs:
       - name: Lint Code Base
         uses: docker://ghcr.io/github/super-linter:slim-v4
         env:
+          # All Environment variables are defined here https://github.com/github/super-linter#environment-variables
+          # The name of the repository default branch.
           DEFAULT_BRANCH: main
+          # Directory for all linter configuration rules. We symlink our root .eslintrc.js to this directory
           LINTER_RULES_PATH: /
           VALIDATE_ALL_CODEBASE: true
           TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.js

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,60 +1,61 @@
 ---
-    ###########################
-    ###########################
-    ## Linter GitHub Actions ##
-    ###########################
-    ###########################
+###########################
+###########################
+## Linter GitHub Actions ##
+###########################
+###########################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all pull requests #
+#############################
+on:
+  pull_request:
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
     name: Lint Code Base
-    
-    #
-    # Documentation:
-    # https://help.github.com/en/articles/workflow-syntax-for-github-actions
-    #
-    
-    #############################
-    # Start the job on all pull requests #
-    #############################
-    on:
-      pull_request_target:
-    
-    ###############
-    # Set the Job #
-    ###############
-    jobs:
-      build:
-        # Name the Job
-        name: Lint Code Base
-        # Set the agent to run on
-        runs-on: ubuntu-latest
-    
-        ##################
-        # Load all steps #
-        ##################
-        steps:
-          ##########################
-          # Checkout the code base #
-          ##########################
-          - name: Checkout Code
-            uses: actions/checkout@v2
+    # Set the agent to run on
+    runs-on: ubuntu-latest
 
-          ##########################
-          # Github Super Linter needs
-          # the latest definitions installed
-          ##########################
-          - name: Use Node.js 16.x
-            uses: actions/setup-node@v2.5.1
-            with:
-              node-version: 16.x
-          - run: npm install
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
 
-          ################################
-          # Run Linter against code base #
-          ################################
-          - name: Lint Code Base
-            uses: docker://ghcr.io/github/super-linter:slim-v4
-            env:
-              DEFAULT_BRANCH: main
-              LINTER_RULES_PATH: /
-              VALIDATE_ALL_CODEBASE: true
-              TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.js
-              VALIDATE_TYPESCRIPT_STANDARD: false
+      ##########################
+      # Github Super Linter needs
+      # the latest definitions installed
+      ##########################
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2.5.1
+        with:
+          node-version: 16.x
+      - run: npm install
+      - run: echo "hi
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: docker://ghcr.io/github/super-linter:slim-v4
+        env:
+          DEFAULT_BRANCH: main
+          LINTER_RULES_PATH: /
+          VALIDATE_ALL_CODEBASE: true
+          TYPESCRIPT_ES_CONFIG_FILE: .eslintrc.js
+          VALIDATE_TYPESCRIPT_STANDARD: false

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -6,11 +6,11 @@ export const getRedisCache = () => {
   return new ElasticacheRedis(
     new RedisCache({
       host: config.redis.primaryEndpoint.split(':')[0],
-      port: config.redis.port
+      port: config.redis.port,
     }),
     new RedisCache({
       host: config.redis.readerEndpoint.split(':')[0],
-      port: config.redis.port
+      port: config.redis.port,
     })
   );
 };


### PR DESCRIPTION
## Goal

https://github.com/Pocket/backend-typescript-template/pull/376 introduced a bunch of linting errors. This is because I changed a bunch of rule sets and assumed they were passing because our status checks passed. 

It turns out that github workflows when using `pull_request_target` https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target will not run any workflow changes from a PR for security purposes, because that type exposes secrets. Because of this my changes were not felt until it was merged to main and then the linter started to fail in other prs.

In this pr I now do 2 things:
* Switch to `pull_request`, we only used `pull_request_target` because we used to have private npm packages that needed a secret. This is no longer the case and a linter shouldn't need secrets. 🤫 
* Add comments to every linter rule to pay a pennance for willy-nilly removing them with no say or ryhme.

## I'd love feedback/perspectives on:
- Are my comments good enough for the crime?

## Implementation Decisions

I used a base rule set from Curated Corpus API and then added each ones documentation. Some rules have since been removed from Github Super Linter so I removed them from our config as well.


## Deployment

We will need to ignore the linter from pull_request_target that is failing and force merge. That is because that is the workflow from the `main` branch failing.